### PR TITLE
Small typo in documentation

### DIFF
--- a/luakeys-doc.tex
+++ b/luakeys-doc.tex
@@ -471,7 +471,7 @@ tex.print(number.todimen(tex.sp('1cm'), 'cm', '%0.0F%s'))
 
 % Wenn die Option \lua{debug} auf true gesetzt ist, wird die
 % Ergebnistabelle in der Konsole ausgegeben.
-If the option \lua{debug} is set to ture, the result table is printed to
+If the option \lua{debug} is set to true, the result table is printed to
 the console.
 
 \InputLatex{opts/debug-latex.tex}


### PR DESCRIPTION
luakeys-doc.tex: If the option debug is set to **ture**, the result table is printed to the console.