### PR TITLE
Add CI/CD

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,9 +16,9 @@ jobs:
           image: maclotsen/texlive:latest
           shell: bash
           options: --rm -i -v ${{ github.workspace }}/texmf:/root/texmf -v ${{ github.workspace }}:/build
-          run: make -C luakeys test ctan
+          run: make test ctan
       - name: Archive Documentation
         uses: actions/upload-artifact@v3
         with:
           name: build
-          path: ${{ github.workspace }}/luakeys
+          path: ${{ github.workspace }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,24 @@
+name: build
+
+on:
+  pull_request:
+    types: [ opened,synchronize ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+      - name: Run the build process with Docker
+        uses: addnab/docker-run-action@v3
+        with:
+          image: maclotsen/texlive:latest
+          shell: bash
+          options: --rm -i -v ${{ github.workspace }}/texmf:/root/texmf -v ${{ github.workspace }}:/build
+          run: make -C luakeys test ctan
+      - name: Archive Documentation
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: ${{ github.workspace }}/luakeys

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,6 +46,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/doc/luakeys-doc.pdf
+          asset_path: ${{ github.workspace }}/luakeys-doc.pdf
           asset_name: luakeys-doc.pdf
           asset_content_type: application/pdf

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
-        with:
-          path: luakeys
       - name: Run the build process with Docker
         uses: addnab/docker-run-action@v3
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,53 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          path: luakeys
+      - name: Run the build process with Docker
+        uses: addnab/docker-run-action@v3
+        with:
+          image: maclotsen/texlive:latest
+          shell: bash
+          options: --rm -i -v ${{ github.workspace }}/texmf:/root/texmf -v ${{ github.workspace }}:/build
+          run: make -C luakeys ctan
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref_name }}
+          draft: true
+          body: |
+            Release for version ${{ github.ref_name }}
+      - name: 'Upload Release Asset: CTAN Upload'
+        id: upload_release_asset_ctan_upload
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/luakeys/luakeys.tar.gz
+          asset_name: luakeys.tar.gz
+          asset_content_type: application/gzip
+      - name: 'Upload Release Asset: Manual'
+        id: upload_release_asset_manual
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/luakeys/doc/luakeys-doc.pdf
+          asset_name: luakeys-doc.pdf
+          asset_content_type: application/pdf

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
           image: maclotsen/texlive:latest
           shell: bash
           options: --rm -i -v ${{ github.workspace }}/texmf:/root/texmf -v ${{ github.workspace }}:/build
-          run: make -C luakeys ctan
+          run: make ctan
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -38,7 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/luakeys/luakeys.tar.gz
+          asset_path: ${{ github.workspace }}/luakeys.tar.gz
           asset_name: luakeys.tar.gz
           asset_content_type: application/gzip
       - name: 'Upload Release Asset: Manual'
@@ -48,6 +48,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/luakeys/doc/luakeys-doc.pdf
+          asset_path: ${{ github.workspace }}/doc/luakeys-doc.pdf
           asset_name: luakeys-doc.pdf
           asset_content_type: application/pdf

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ test_examples_latex:
 
 test_tex: test_tex_plain test_tex_latex
 test_tex_plain:
-	find tests/tex/plain -iname "*.tex" -exec luatex --output-dir=tests/tex/plain {} \;
+	find tests/tex/plain -iname "*.tex" -exec luatex --interaction=nonstopmode --output-dir=tests/tex/plain {} \;
 test_tex_latex:
-	find tests/tex/latex -iname "*.tex" -exec lualatex --output-dir=tests/tex/latex {} \;
+	find tests/tex/latex -iname "*.tex" -exec lualatex --interaction=nonstopmode --output-dir=tests/tex/latex {} \;
 
 doc: doc_pdf
 

--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,19 @@ texmf = $(HOME)/texmf
 texmftex = $(texmf)/tex/luatex
 installdir = $(texmftex)/$(jobname)
 
-all: install doc_lua
+all: install
 
-install: uninstall_texlive install_quick
-
-uninstall_texlive:
-	-tlmgr uninstall --force luakeys
-
-install_quick:
+install: doc_pdf
 	mkdir -p $(installdir)
 	cp -f $(jobname).lua $(installdir)
 	cp -f $(jobname).sty $(installdir)
 	cp -f $(jobname).tex $(installdir)
 	cp -f $(jobname)-debug.tex $(installdir)
 	cp -f $(jobname)-debug.sty $(installdir)
+	mkdir -p $(texmf)/doc
+	cp luakeys-doc.pdf $(texmf)/doc/$(jobname).pdf
 
-test: install test_lua test_examples test_tex doc_pdf
+test: test_lua test_examples test_tex doc_pdf
 
 test_lua:
 	busted --lua=/usr/bin/lua5.3 --exclude-tags=skip tests/lua/test-*.lua
@@ -44,8 +41,6 @@ doc_pdf:
 	makeindex -s gglo.ist -o luakeys-doc.gls luakeys-doc.glo
 	makeindex -s gind.ist -o luakeys-doc.ind luakeys-doc.idx
 	lualatex --shell-escape luakeys-doc.tex
-	mkdir -p $(texmf)/doc
-	cp luakeys-doc.pdf $(texmf)/doc/$(jobname).pdf
 
 ctan: doc_pdf
 	rm -rf $(jobname).tar.gz


### PR DESCRIPTION
In order to introduce continuous integration and delivery, the Makefile had to be changed. All targets have been changed to not interact with TEXMFHOME, except for the `install` target.

It also introduces two GitHub workflows using the [xdp-docker](https://github.com/Xerdi/xdp-docker) Docker image. If you want to have your own Docker image, the [last commit](https://github.com/Xerdi/xdp-docker/commit/250e52ea397e69b8d9955bf5fbecbea8a9bb8b26) contains all luakeys specific dependencies.