### PR TITLE
Add another world example (picking versions)

### DIFF
--- a/luakeys.lua
+++ b/luakeys.lua
@@ -1621,6 +1621,8 @@ local function main()
                 local picked_value = nil
                 if is[pick_type](v) then
                   picked_value = v
+                elseif pick_type == 'string' and is.number(v) then
+                  picked_value = tostring(v)
                 end
 
                 if picked_value ~= nil then

--- a/tests/lua/test-defs.lua
+++ b/tests/lua/test-defs.lua
@@ -366,7 +366,7 @@ describe('Defintions', function()
       end)
 
       it('string', function()
-        assert_pick('string', 'A string', '1,"A string"')
+        assert_pick('string', '1', '1,"A string"')
       end)
 
       it('Error: unknown data type', function()

--- a/tests/lua/test-real-world.lua
+++ b/tests/lua/test-real-world.lua
@@ -10,24 +10,6 @@ end
 
 describe('Real world examples', function()
   describe('gitinfo-lua', function()
-    it('Manual page ?: 0.0.1,flags={no-merges}', function()
-      local parse_commit_opts = luakeys.define({
-        rev_spec = { data_type = 'string', pick = 'string' },
-        files = { data_type = 'list' },
-        cwd = { data_type = 'string' },
-        flags = {
-          sub_keys = {
-            merges = { data_type = 'boolean', exclusive_group = 'merges' },
-            ['no-merges'] = { data_type = 'boolean', exclusive_group = 'merges' }
-          }
-        }
-      })
-      local actual = '0.0.1,flags={no-merges}'
-      local expected = { flags = { ['no-merges'] = true }, rev_spec = '0.0.1' }
-      assert.are.same(expected, parse_commit_opts(actual))
-    end)
-  end)
-  describe('gitinfo-lua', function()
     it('Manual page ?: 0.1,flags={no-merges}', function()
       local parse_commit_opts = luakeys.define({
         rev_spec = { data_type = 'string', pick = 'string' },

--- a/tests/lua/test-real-world.lua
+++ b/tests/lua/test-real-world.lua
@@ -27,6 +27,24 @@ describe('Real world examples', function()
       assert.are.same(expected, parse_commit_opts(actual))
     end)
   end)
+  describe('gitinfo-lua', function()
+    it('Manual page ?: 0.1,flags={no-merges}', function()
+      local parse_commit_opts = luakeys.define({
+        rev_spec = { data_type = 'string', pick = 'string' },
+        files = { data_type = 'list' },
+        cwd = { data_type = 'string' },
+        flags = {
+          sub_keys = {
+            merges = { data_type = 'boolean', exclusive_group = 'merges' },
+            ['no-merges'] = { data_type = 'boolean', exclusive_group = 'merges' }
+          }
+        }
+      })
+      local actual = '0.1,flags={no-merges}'
+      local expected = { flags = { ['no-merges'] = true }, rev_spec = '0.1' }
+      assert.are.same(expected, parse_commit_opts(actual))
+    end)
+  end)
   describe('hyperref', function()
     it('Manual page 6: pdfborder={0 0 0}', function()
       assert_deep_equals('pdfborder={0 0 0}', { pdfborder = '0 0 0' })


### PR DESCRIPTION
Currently, versions like 1.0 won't be parsed correctly if configured as picked with string type.
Added a reproducible test failure. While it may look identical as the previous test case, this case is especially hard, since it's actually a valid number type, which IMHO can also be a string and should be parsed as string if it's defined as string.

Let me know if this behavior is wanted, or if it's out of reach for the scope of `luakeys`. Users that use `gitinfo-lua` can simply avoid this matter by prefixing versions with a `v`, like `v1.0`, though, hopefully both will work in the future ;)